### PR TITLE
Escape spaces in passage name in visited tag

### DIFF
--- a/story-javascript.js
+++ b/story-javascript.js
@@ -329,7 +329,7 @@ QBN.functions = {
 	},
 	visited: {
 		match: /^visited-([^-]+)/,
-		action: function(m) { return visited(m[1]) > 0 },
+		action: function(m) { return visited(m[1].replace(/_/g, ' ')) > 0 },
 		description: function(m) { return null }
 	},
 	random: {


### PR DESCRIPTION
Ensure that spaces in passage titles are escaped in the visited expression.  